### PR TITLE
Updates to reflect Elza Homestead moving.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-_site
+_site/*
 .sass-cache

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -5,12 +5,10 @@
 		<ul class="right hide-on-med-and-down">
 			<li><a href="/">Home</a></li>
 			<li><a href="/about">About</a></li>
-			<li><a href="/order">Where to Buy</a></li>
 		</ul>
 		<ul class="side-nav" id="mobile-demo">
 			<li><a href="/">Home</a></li>
 			<li><a href="/about">About</a></li>
-			<li><a href="/order">Where to Buy</a></li>
 		</ul>
 	</div>
 </nav>

--- a/about.md
+++ b/about.md
@@ -10,5 +10,4 @@ We are a family homestead based business focused on local and sustainable food p
 <br>
 
 Jared Elza  
-Elza Homestead  
-Wautoma, WI 54982  
+Elza Homestead

--- a/order.md
+++ b/order.md
@@ -3,47 +3,8 @@ layout: page
 title: Where to Buy
 permalink: /order/
 ---
-#### RETAIL OUTLETS
-
-Kountry Pride Farms, Sauasage and Meat Shop  
-8899 State Road 21  
-Omro, WI  
-
-Mon-Fri:	8:30 am - 5:30 pm  
-Sat:	8:00 am - 2:00 pm  
-
-[Kountry Pride Farms on Facebook](https://www.facebook.com/Kountry-Pride-Farms-Sausage-Meat-Shop-193450167341775/)
-
-FRESH deliveries on Wednesdays!
-
-Available Now:  
-* Speckled Pea Microgreens  
-* Triton Purple Radish Microgreens  
-* Artisan Salad Mix 
-
-In the Future:  
-* Genovese Italian Basil Microgreens
-* Greens: Spinach, Kale, Arugula, Tatsoi, and more  
-* Living Head Lettuce  (Aquaponic)  
-* Yellow Perch (raised in Aquaponics) 
-* Suggestions welcome!  
-
-Kountry Pride Farms is our exclusive retailer for Omro, Berlin, Oshkosh, Larsen, Winneconnie, Eureka, Poysippi and the surrounding areas!
-
-<br><br><br><br>
-<br><br><br><br>
-
-#### RESTAURANTS
-
-Little Fat Gretchen's  
-108 S Main St  
-Waupaca, WI
-
-Mon-Thu:	6:00 am - 7:00 pm  
-Fri-Sat:	6:00 am - 8:00 pm  
-Sun:	6:00 am - 7:00 pm  
-
-[Little Fat Gretchen on Facebook](https://www.facebook.com/LittleFatGretchens/)
+#### Elza Homestead Has Moved!
+Elza Homestead has moved to the Michigan upper peninsula. We are still settling in to our new home, but are continuing to homestead.
 
 <br><br><br><br>
 <br><br><br><br>
@@ -55,3 +16,48 @@ All wholesale inquiries are welcome including: Restaurants, Grocers, CO-OPs, CSA
 For more info please contact us:  
 Email: jared@elzahomestead.com  
 Call Jared: (920)215-9623  
+
+<br><br><br><br>
+<br><br><br><br>
+
+#### ~~RETAIL OUTLETS~~
+
+~~Kountry Pride Farms, Sauasage and Meat Shop~~  
+~~8899 State Road 21~~  
+~~Omro, WI~~  
+
+~~Mon-Fri:	8:30 am - 5:30 pm~~  
+~~Sat:	8:00 am - 2:00 pm~~  
+
+[~~Kountry Pride Farms on Facebook~~](https://www.facebook.com/Kountry-Pride-Farms-Sausage-Meat-Shop-193450167341775/)
+
+~~FRESH deliveries on Wednesdays!~~
+
+~~Available Now:~~  
+* ~~Speckled Pea Microgreens~~  
+* ~~Triton Purple Radish Microgreens~~  
+* ~~Artisan Salad Mix~~ 
+
+~~In the Future:~~  
+* ~~Genovese Italian Basil Microgreens~~
+* ~~Greens: Spinach, Kale, Arugula, Tatsoi, and more~~  
+* ~~Living Head Lettuce  (Aquaponic)~~  
+* ~~Yellow Perch (raised in Aquaponics)~~ 
+* ~~Suggestions welcome!~~  
+
+~~Kountry Pride Farms is our exclusive retailer for Omro, Berlin, Oshkosh, Larsen, Winneconnie, Eureka, Poysippi and the surrounding areas!~~
+
+<br><br><br><br>
+<br><br><br><br>
+
+#### ~~RESTAURANTS~~
+
+~~Little Fat Gretchen's~~  
+~~108 S Main St~~  
+~~Waupaca, WI~~
+
+~~Mon-Thu:	6:00 am - 7:00 pm~~  
+~~Fri-Sat:	6:00 am - 8:00 pm~~  
+~~Sun:	6:00 am - 7:00 pm~~  
+
+[~~Little Fat Gretchen on Facebook~~](https://www.facebook.com/LittleFatGretchens/)~~


### PR DESCRIPTION
Since Elza Homestead has moved to the UP, I made changes to the order page, header, and about page to reflect the current state of things.